### PR TITLE
Partly-rewritten sidulator. WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 KICKASM_CMD=java -jar ~/bin/KickAssembler/KickAss.jar
 
-CFLAGS=-std=c99
+CFLAGS=-std=c99 -O2
 SOURCES=sidulator.c
 
 .DEFAULT_GOAL:=all
@@ -11,7 +11,13 @@ player.prg: src/player.asm
 sidulator: src/$(SOURCES)
 	$(CC) $(CFLAGS) $< -o $@
 
-all: player.prg sidulator
+sidulator2: src/sidulator2.c
+	$(CC) $(CFLAGS) $< -o $@
+
+analyzeusage: src/analyzeusage.c
+	$(CC) $(CFLAGS) $< -o $@
+
+all: player.prg sidulator sidulator2 analyzeusage
 
 run: all
 	./sidulator -f testfiles/music_2_0800.sid -d music_2_0800.diff --playerprg player.prg -i 0x20 -t 0x10 -l 0x0800 -s 0x7e -c 100000 --overwrite --ignoresidregs -g 0xfe-0xff -v

--- a/src/analyzeusage.c
+++ b/src/analyzeusage.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <string.h>
+
+int usages[65536];
+
+int main(int argc, char* argv[])
+{
+    memset(usages, 0, sizeof(int)*65536);
+    while(!feof(stdin))
+    {
+        char rivi[256];
+        fgets(rivi, 256, stdin);
+        rivi[255] = 0;
+
+        int addr = 0;
+        int finalval = 0;
+        int count = 0;
+        sscanf(rivi, "%X: %X %d", &addr, &finalval, &count);
+        //printf("%X %X %X\n", addr, finalval, count);
+
+        usages[addr]++;
+    }
+
+    char chars[] = { '.', '1', '2', '3', '4', '5', '6', '7', '8', '9', '#' };
+    int cc = sizeof(chars) / sizeof(chars[0]);
+
+    for (int y = 0; y < 256; y++)
+    {
+        printf("%04X: ", y*256+0);
+        for (int x = 0; x < 128; x++)
+            fputc( chars [ usages[y*256+x] >= cc ? (cc - 1) : usages[y*256+x] ], stdout);
+        //fputc('\n', stdout);
+
+        //printf("%04X: ", y*256+128);
+        for (int x = 128; x < 256; x++)
+            fputc( chars [ usages[y*256+x] >= cc ? (cc - 1) : usages[y*256+x] ], stdout);
+        fputc('\n', stdout);
+    }
+}

--- a/src/sidulator2.c
+++ b/src/sidulator2.c
@@ -35,7 +35,7 @@ static struct option long_options[] = {
     {"printmem", no_argument,                   0, 'm'},
     {"checkmem", required_argument,             0, 'r'},
     {"clear",    no_argument,                   0, 'c'},
-    {"asm",      required_argument,             0, 'a'},
+    {"asm",      no_argument,                   0, 'a'},
     {"help",     no_argument,                   0, 'h'},
     {0, 0, 0, 0}
 
@@ -227,13 +227,13 @@ void printRangesWithMask(int mask) {
     }
 }
 
-void printAsmWithMask(int mask, const char* fn) {
+void printAsmWithMask(int mask) {
     for (int i = 0; i <= 0xFFFF; i++)
     {
         if ( memory_states[i] & mask)
         {
-            printf("LDA #$%02X\n", memory[i]);
-            printf("STA $%04X\n", i);
+            printf("lda #$%02X\n", memory[i]);
+            printf("sta $%04X\n", i);
         }
     }
 }
@@ -375,7 +375,7 @@ int main(int argc, char** argv) {
 
             case 'a':
                 verbose("Generating asm:\n");
-                printAsmWithMask(MEMSTATE_WRITTEN, optarg);
+                printAsmWithMask(MEMSTATE_WRITTEN);
                 break;
 
 

--- a/src/sidulator2.c
+++ b/src/sidulator2.c
@@ -172,12 +172,15 @@ void runUntilRTS(uint16_t newpc, uint8_t accu) {
 
 }
 
-void RunSid(int frameCount, int subTune, uint16_t initAddr, uint16_t playAddr) {
-    //reset6502();
-
+void callInit(int subTune, uint16_t initAddr)
+{
     verbose("Begin emulation..");
     runUntilRTS(initAddr, subTune);
     verbose(".");
+}
+
+void RunSid(int frameCount, uint16_t playAddr) {
+    //reset6502();
 
     for (int i = 0; i < frameCount; i++)
     {
@@ -312,6 +315,10 @@ int main(int argc, char** argv) {
                 }
                 break;
 
+            case 'h':
+                printHelp();
+                break;
+
             case 'v':
                 verbose("Verbose mode\n");
                 flag_verbose = 'v';
@@ -325,7 +332,7 @@ int main(int argc, char** argv) {
                 }
                 frameCount = (int)strtol(optarg, NULL, 0);
                 verbose("emulating %d frames\n", frameCount);
-                RunSid(frameCount, subTune, initAddr, playAddr);
+                RunSid(frameCount, playAddr);
 
                 ignoreRegion(0x0100, 0x01ff); // ignore stack
                 break;
@@ -338,6 +345,7 @@ int main(int argc, char** argv) {
             case 't':
                 subTune = (int)strtol(optarg, NULL, 0);
                 verbose("using subtune %d\n", subTune);
+                callInit(subTune, initAddr);
                 break;
 
             case 'm':

--- a/src/sidulator2.c
+++ b/src/sidulator2.c
@@ -1,0 +1,388 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdbool.h>
+#include <math.h>
+#include <arpa/inet.h>
+
+#define FAKE6502_USE_STDINT
+#include "../3rdparty/fake6502/fake6502.h"
+
+#define VERSION "0.1.1"
+
+#define MAXFRAMES 100000000
+
+static int flag_verbose = 0;
+int verbose(const char * restrict format, ...) {
+    if (!flag_verbose) { return 0; }
+
+    va_list args;
+    va_start(args, format);
+    int retval = vfprintf(stderr, format, args);
+    va_end(args);
+
+    return retval;
+}
+
+
+static struct option long_options[] = {
+    {"sidfile", required_argument, 0, 'f'},
+    {"emulate", required_argument, 0, 'e'},
+    {"verbose", no_argument, &flag_verbose, 'v'},
+    {"subtune", no_argument, 0, 't'},
+    {"printmem", no_argument, 0, 'm'},
+    {"checkmem", required_argument, 0, 'r'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}
+
+};
+
+void printHelp() {
+    printf("OPTIONS:\n");
+    for (size_t i = 0; i < sizeof(long_options)/sizeof(long_options[0]); i++) {
+        if (long_options[i].val == 0) { continue; }
+
+        fprintf(stderr, "\t-%c, --%s\n", long_options[i].val, long_options[i].name);
+    }
+}
+
+
+
+#define MEMSIZE 65536
+static uint8 memory[MEMSIZE];
+static uint8 memory_states[MEMSIZE];
+static int memory_count[MEMSIZE];
+static bool memory_init[MEMSIZE];
+
+#define MEMSTATE_READ (1)
+#define MEMSTATE_WRITTEN (2)
+#define MEMSTATE_INIT (4)
+
+#define MEMSTATE_ALL (7)
+
+
+uint8 read6502(ushort addr) {
+    //verbose(" - read from %04X (%02x)\n", addr, memory[addr]);
+    memory_states[addr] |= MEMSTATE_READ;
+    memory_count[addr]++;
+    return memory[addr];
+}
+
+void write6502(ushort addr, uint8 val) {
+    //verbose(" - write to %04X (%02X)\n", addr, val);
+    memory_states[addr] |= MEMSTATE_WRITTEN;
+    memory_count[addr]++;
+    memory[addr] = val;
+}
+
+void clearMemory(uint8 value) {
+    memset(memory, value, sizeof(memory)/sizeof(memory[0]));
+    memset(memory_states, 0, sizeof(memory_states)/sizeof(memory_states[0]));
+    memset(memory_count, 0, sizeof(memory_count)/sizeof(memory_count[0]));
+    memset(memory_init, 0, sizeof(memory_init)/sizeof(memory_init[0]));
+}
+
+
+
+
+
+void loadSid(const char* filename, uint16_t* initAddr, uint16_t* playAddr) {
+    verbose("Loading sid %s\n", filename);
+    FILE *fp = fopen(filename, "r");
+    if (!fp) { 
+        fprintf(stderr, "Couldn't open file `%s`. Exiting...\n", filename);
+        exit(1);
+    }
+
+    fseek(fp, 0, SEEK_END);
+    long filesize = ftell(fp);
+
+    fseek(fp, 0, SEEK_SET);
+
+    uint8_t header[0x7C];
+    fread(header,1, 0x7C, fp);
+
+    uint16_t version = ntohs(*(uint16_t*)&(header[0x4]));
+    uint16_t dataoffs = ntohs(*(uint16_t*)&(header[0x6]));
+
+
+    verbose("SIDINFO: sid version %d\n", version);
+
+
+
+    uint16_t loadaddr = ntohs(*(uint16_t*)&(header[0x8]));
+    *initAddr = ntohs(*(uint16_t*)&(header[0xA]));
+    *playAddr = ntohs(*(uint16_t*)&(header[0xC]));
+    uint32_t ident = *(uint32_t*)&(header[0x0]);
+
+    fseek(fp, dataoffs, SEEK_SET);
+
+    if (loadaddr == 0)
+        fread( &loadaddr, 2, 1, fp);
+
+    long datalen = filesize - ftell(fp);
+
+
+    verbose("SIDINFO: id %08X\n", ident);
+    verbose("SIDINFO: load address: $%04X-$%04X\n", loadaddr, (int)(loadaddr+datalen-1));
+    verbose("SIDINFO: init address: $%04X\n", *initAddr);
+    verbose("SIDINFO: play address: $%04X\n", *playAddr);
+    verbose("SIDINFO: name: %s\n", &(header[0x16]));
+    verbose("SIDINFO: author: %s\n", &(header[0x36]));
+    verbose("SIDINFO: copyright: %s\n", &(header[0x56]));
+
+    fread(&(memory[loadaddr]), 1, datalen, fp);
+
+    for (int i = 0; i < datalen; i++)
+    {
+        memory_init[ loadaddr + i] = true;
+        memory_states[ loadaddr + i ] |= MEMSTATE_INIT;
+    }
+
+    fclose(fp);
+}
+
+#define STACK_END (0x1FE)
+
+void runUntilRTS(uint16_t newpc, uint8_t accu) {
+    pc = newpc;
+    a = accu;
+    sp = 0xFD;
+    status = 0;
+    memory[STACK_END] = 0xFE;
+    memory[STACK_END+1] = 0xFF;
+
+    //while(sp <= 0xFD)
+    while(pc != 0xFFFF)
+    {
+        //printf("pc %04X: sp %d\n", pc, sp);
+        step6502();
+    }
+
+    // alles good if the stack end was accessed only once
+    if (memory_count[STACK_END] == 1 && memory_count[STACK_END+1] == 1)
+    {
+        memory_states[STACK_END] = 0;
+        memory_states[STACK_END+1] = 0;
+        memory_count[STACK_END] = 0;
+        memory_count[STACK_END+1] = 0;
+    }
+
+}
+
+void RunSid(int frameCount, int subTune, uint16_t initAddr, uint16_t playAddr) {
+    //reset6502();
+
+    verbose("Begin emulation..");
+    runUntilRTS(initAddr, subTune);
+    verbose(".");
+
+    for (int i = 0; i < frameCount; i++)
+    {
+        runUntilRTS(playAddr, 0);
+        if (!(i%1000))
+            verbose(".");
+    }
+    verbose("\n");
+}
+
+void printAllWithMask(int mask) {
+    char* statestrs[] = { "", "read", "written", "read/written", "init", "init/read", "init/written", "init/read/written" };
+    for (int i = 0; i <= 0xFFFF; i++)
+    {
+        if ( memory_states[i] & mask)
+        {
+            char* statestr = statestrs[ memory_states[ i ] ];
+            printf("%04X: %02X %d (%s)\n", i, memory[ i ], memory_count[i], statestr);
+        }
+    }
+}
+
+void printRangesWithMask(int mask) {
+    bool flag = false;
+    int rangestart, rangeend;
+    for (int i = 0; i <= 0xFFFF; i++)
+    {
+        if (!flag && (memory_states[i] & mask))
+        {
+            flag = true;
+            rangestart = i;
+        }
+        else if (flag && !(memory_states[i] & mask))
+        {
+            flag = false;
+            rangeend = i;
+
+            printf("range: %04X-%04X\n", rangestart, rangeend-1);
+            
+        }
+    }
+
+}
+
+int checkUsage(uint16_t startAddr, uint16_t endAddr) {
+    int s = startAddr < endAddr ? startAddr : endAddr;
+    int e = startAddr > endAddr ? startAddr : endAddr;
+
+    if (s == e) {
+        verbose("Checking usage of address 0x%04x\n", s);
+    } else {
+        verbose("Checking usage of region 0x%04x - 0x%04x\n", s, e);
+    }
+
+    for (int i = s; i <= e; i++) {
+        if ( memory_states[i] )
+        {
+            fprintf(stderr, "Region $%04X-%04X used by tune!\n", s, e);
+            return 1;
+        }
+    }
+
+    return 0;
+
+}
+
+void ignoreRegion(uint16_t startAddr, uint16_t endAddr) {
+    int s = startAddr < endAddr ? startAddr : endAddr;
+    int e = startAddr > endAddr ? startAddr : endAddr;
+
+    if (s == e) {
+        verbose("Ignoring address 0x%04x\n", s);
+    } else {
+        verbose("Ignoring region 0x%04x - 0x%04x\n", s, e);
+    }
+
+    for (int i = s; i <= e; i++) {
+        memory_states[i] = 0;
+        memory_count[i] = 0;
+    }
+}
+
+void markRegion(uint16_t startAddr, uint16_t endAddr) {
+    int s = startAddr < endAddr ? startAddr : endAddr;
+    int e = startAddr > endAddr ? startAddr : endAddr;
+
+    if (s == e) {
+        verbose("Including address 0x%04x\n", s);
+    } else {
+        verbose("Including region 0x%04x - 0x%04x\n", s, e);
+    }
+
+    for (int i = s; i <= e; i++) {
+        memory_states[i] |= MEMSTATE_ALL;
+    }
+}
+
+int main(int argc, char** argv) {
+    verbose("SIDulator v%s - Pre-replays a sid file to the correct position and saves the diff\n", VERSION);
+
+    int c = 0;
+
+    //char* diff_filename = NULL;
+    //char* loadaddr_str = NULL;
+    //char* skipbytes_str = NULL;
+    //char* includeregions_str = NULL;
+
+
+    clearMemory(0);
+
+    uint16_t initAddr = 0;
+    uint16_t playAddr = 0;
+
+    int subTune = 0;
+    int frameCount = 6*60*50;
+
+    do {
+        int option_index = 0;
+        c = getopt_long(argc, argv, "f:e:vt:mhr:", long_options, &option_index);
+
+        if (c < 0) { break; }
+
+        switch (c) {
+            case 0:
+                /* If this option set a flag, do nothing else now. */
+                if (long_options[option_index].flag != 0) { break; }
+
+                printf("option %s", long_options[option_index].name);
+
+                if (optarg) {
+                    printf(" with arg %s\n", optarg);
+                }
+                break;
+
+            case 'v':
+                verbose("Verbose mode\n");
+                flag_verbose = 'v';
+                break;
+
+            case 'e':
+                if (initAddr == 0 || playAddr == 0)
+                {
+                    fprintf(stderr, "can't emulate without program\n");
+                    exit(1);
+                }
+                frameCount = (int)strtol(optarg, NULL, 0);
+                verbose("emulating %d frames\n", frameCount);
+                RunSid(frameCount, subTune, initAddr, playAddr);
+
+                ignoreRegion(0x0100, 0x01ff); // ignore stack
+                break;
+
+            case 'f':
+                verbose("loading sid `%s`\n", optarg);
+                loadSid(optarg, &initAddr, &playAddr);
+                break;
+
+            case 't':
+                subTune = (int)strtol(optarg, NULL, 0);
+                verbose("using subtune %d\n", subTune);
+                break;
+
+            case 'm':
+                verbose("Printing used memory:\n");
+                printAllWithMask(MEMSTATE_ALL);
+                break;
+
+            case 'r':
+            {
+                int beg,end;
+                sscanf(optarg, "%X-%X", &beg, &end);
+                if (checkUsage(beg,end))
+                    exit(2);
+                break;
+            }
+
+//            case 'r':
+//                verbose("Check memory usage with rules='%s'", optarg);
+//                rulefile_str = optarg;
+
+            default:
+                exit(1);
+        }
+    } while (c >= 0);
+
+/*
+    if (optind < argc) {
+        printf("Extra arguments given (maybe you got something wrong?): ");
+
+        while (optind < argc) {
+            printf("%s ", argv[optind++]);
+        }
+
+        putchar('\n');
+    }
+*/
+
+
+    //ignoreRegion(0x0000, 0x00ff); // ignore zp
+    //ignoreRegion(0xd400, 0xd7ff);
+
+
+    //printRangesWithMask(MEMSTATE_READ);
+    //printRangesWithMask(MEMSTATE_WRITTEN);
+
+    return 0;
+}
+

--- a/testfiles/test.sh
+++ b/testfiles/test.sh
@@ -1,0 +1,2 @@
+../sidulator2 -f flipdisk.sid -t 1 -c -e 100 -a > sidskip.asm
+java -jar ~/bin/kickass/KickAss.jar testplayer.asm

--- a/testfiles/testplayer.asm
+++ b/testfiles/testplayer.asm
@@ -1,0 +1,75 @@
+//---------------------------------------------------------
+//---------------------------------------------------------
+//                     SID Player
+//---------------------------------------------------------
+//---------------------------------------------------------
+        .var music = LoadSid("flipdisk.sid")
+        BasicUpstart2(start)
+start:
+        lda #$00
+        sta $d020
+        sta $d021
+        ldx #0
+        ldy #0
+        lda #music.startSong-1
+        jsr music.init
+
+.import source "sidskip.asm"
+
+
+        sei
+        lda #<irq1
+        sta $0314
+        lda #>irq1
+        sta $0315
+        asl $d019
+        lda #$7b
+        sta $dc0d
+        lda #$81
+        sta $d01a
+        lda #$1b
+        sta $d011
+        lda #$80
+        sta $d012
+        cli
+        jmp *
+//---------------------------------------------------------
+irq1:
+        asl $d019
+        inc $d020
+        jsr music.play 
+        dec $d020
+        pla
+        tay
+        pla
+        tax
+        pla
+        rti
+//---------------------------------------------------------
+        *=music.location "Music"
+        .fill music.size, music.getData(i)
+
+//----------------------------------------------------------
+// Print the music info while assembling
+.print ""
+.print "SID Data"
+.print "--------"
+.print "location=$"+toHexString(music.location)
+.print "init=$"+toHexString(music.init)
+.print "play=$"+toHexString(music.play)
+.print "songs="+music.songs
+.print "startSong="+music.startSong
+.print "size=$"+toHexString(music.size)
+.print "name="+music.name
+.print "author="+music.author
+.print "copyright="+music.copyright
+
+.print ""
+.print "Additional tech data"
+.print "--------------------"
+.print "header="+music.header
+.print "header version="+music.version
+.print "flags="+toBinaryString(music.flags)
+.print "speed="+toBinaryString(music.speed)
+.print "startpage="+music.startpage
+.print "pagelength="+music.pagelength


### PR DESCRIPTION
Some more improvements to Sidulator. Should be more modular and usable for more applications. Old functionality (=generating memory diff that skips N frames of sid playback) has been implemented also. There were so many changes that I just copied code to a new file (sidulator2.c) and was planning to rename that back to sidulator.c once the original functionality has been verified.

Changes:
- Removal of the .asm file. (just uses stack to know when playroutine has exited)
- Options to dump and analyze memory usage stats.
- Command-line usage has been changed from "declarative" to something resembling a mini-program. Multiple lower-level operations can be combined to perform higher level tasks.

Also added testfiles/test.sh that shows how to create a .prg that starts playing sid file with first 100 frames skipped.